### PR TITLE
changed foo, bar, baz to more sensible examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,12 +79,12 @@ document.body.appendChild(table);
       Laconic adds a method to the $.el namespace for all known 
       <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/section-index.html#elements-1">HTML tags</a>.  These methods should be invoked with a variable length list of child elements or strings. An optional attributes object may be passed as the first argument.  For example:
     </p>
-<pre><code class='language-javascript'>$.el.div({'class' : 'foo'}, $.el.div('bar'));</code></pre>
+<pre><code class='language-javascript'>$.el.div({'class' : 'example-class'}, $.el.div('Content'));</code></pre>
     <p>
       will produce the following structure:
     </p>
-<pre><code class='language-html'>&lt;div class='foo'&gt;
-  &lt;div&gt;bar&lt;div/&gt;
+<pre><code class='language-html'>&lt;div class='example-class'&gt;
+  &lt;div&gt;Content&lt;div/&gt;
 &lt;/div&gt;
 </code></pre>
     
@@ -95,7 +95,7 @@ document.body.appendChild(table);
       reference to the root node of the tag.  For example:
     </p>
 
-<pre><code class='language-javascript'>$.el.registerTag('foo', function(one, two) {
+<pre><code class='language-javascript'>$.el.registerTag('element', function(one, two) {
   this.appendChild($.el.div(one));
   this.appendChild($.el.div(two));
 });
@@ -104,15 +104,15 @@ document.body.appendChild(table);
       Once you've registered a tag, you can start inserting it:
     </p>
 
-<pre><code class='language-javascript'>$.el.foo('bar', 'baz').appendTo(document.body);</code></pre>
+<pre><code class='language-javascript'>$.el.element('First', 'Second').appendTo(document.body);</code></pre>
 
     <p>
       This particular invocation will produce the following structure:
     </p>
 
-<pre><code class='language-html'>&lt;div class='foo'&gt;
-  &lt;div&gt;bar&lt;/div&gt;
-  &lt;div&gt;baz&lt;/div&gt;
+<pre><code class='language-html'>&lt;div class='element'&gt;
+  &lt;div&gt;First&lt;/div&gt;
+  &lt;div&gt;Second&lt;/div&gt;
 &lt;/div&gt;
 </code></pre>
 


### PR DESCRIPTION
See also http://linguapragma.com/blog/2012/04/foo-bar-and-baz-not-having-it/
