### PR TITLE
Fix creating a button with a type under IE7

### DIFF
--- a/laconic.js
+++ b/laconic.js
@@ -33,6 +33,24 @@
     'vspace'            : 'vSpace'
   };
 
+  var needsButtonHack = (function() {
+    var button = document.createElement("button");
+    var needsButtonHack = false;
+
+    button.setAttribute("type", "submit");
+    if (button.type !== "submit") {
+      try {
+        button = document.createElement('<button type="submit">');
+        needsButtonHack = button.type === "submit";
+      } catch (e) {
+        // Standards-compliant browsers will throw an exception on that
+        // createElement.
+      }
+    }
+
+    return needsButtonHack;
+  })();
+
   // The laconic function serves as a generic method for generating
   // DOM content, and also as a placeholder for helper functions.
   //
@@ -47,11 +65,21 @@
   // 
   // for example:
   // laconic('div', {'class' : 'foo'}, 'bar');
-  function laconic() {
+  function laconic(tagName) {
 
     // create a new element of the requested type
-    var el = document.createElement(arguments[0]);
-    
+    var el;
+    if(tagName.toLowerCase() == 'button' && needsButtonHack) {
+      var buttonType = (arguments[1] || {}).type || "button";
+      el = document.createElement(
+        '<' + tagName + ' type="' + buttonType + '">'
+      );
+    }
+
+    else {
+      el = document.createElement(tagName);
+    }
+
     // walk through the rest of the arguments
     for(var i=1; i<arguments.length; i++) {
       var arg = arguments[i];

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -36,11 +36,18 @@ $(document).ready(function() {
       labelAttributes[forName] = 'foo';
       var label = $.el.label(labelAttributes);
 
-
       equal(input.getAttribute('name'), 'foo');
       equal(input.getAttribute('type'), 'text');
 
       equal((label.getAttribute('for') || label.getAttribute('htmlFor')), 'foo');
     });
+  });
+
+  test("button type attribute", function() {
+    var results = [];
+
+    var button = $.el.button({type: "submit"}, "Send");
+    equal(button.getAttribute("type"), "submit", "type: getAttribute()");
+    equal(button.type, "submit", "type: direct property access");
   });
 });


### PR DESCRIPTION
A `<button>`'s type cannot be changed with `setAttribute` under IE7:

``` javascript
var button = document.createElement("button");
button.setAttribute("type", "submit");

console.log(button.getAttribute("type")); // "submit" (even in IE7)
console.log(button.type);                 // "button" in IE7
```

The button continues to act like `<button type="button">`, and it cannot be used to submit a form in IE7 without adding a click event handler.

The only workaround I know of is IE's proprietary `createElement` syntax where you can specify attributes inline, and this pull request implements that workaround.
