### PR TITLE
Use 'this' keyword instead of el

### DIFF
--- a/laconic.js
+++ b/laconic.js
@@ -132,7 +132,7 @@
       if(parentNode.nodeType === 1 && this.nodeType === 1) {
         parentNode.appendChild(this);
       }
-      return el;
+      return this;
     };
     
     return el;


### PR DESCRIPTION
Using `el`, creates an unnecessary closure of `el` - this will create a memory leak as dom node cannot be garbage collected.
